### PR TITLE
Fix Uncaught TypeError

### DIFF
--- a/src/keymap-manager.coffee
+++ b/src/keymap-manager.coffee
@@ -502,7 +502,7 @@ class KeymapManager
     if character = characterForKeyboardEvent(keydownEvent)
       textInputEvent = document.createEvent("TextEvent")
       textInputEvent.initTextEvent("textInput", true, true, window, character)
-      keydownEvent.path[0].dispatchEvent(textInputEvent)
+      keydownEvent.currentTarget.dispatchEvent(textInputEvent)
 
   # For testing purposes
   getOtherPlatforms: -> OtherPlatforms


### PR DESCRIPTION
`path` is a non-standard property that was removed in chromium 110 causing this code to throw errors when encountered. the whatwg dom spec lists it's replacement, `composedPath()`, as having the first element always be currentTarget so just use that instead.


https://groups.google.com/a/chromium.org/g/blink-dev/c/UYY2TRSL8_k
https://dom.spec.whatwg.org/#dom-event-composedpath